### PR TITLE
Arreglar import y exports

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,8 +13,10 @@
 var dt = new Date();
 document.getElementById("datetime").innerHTML = (("0"+(dt.getMonth()+1)).slice(-2)) +"/"+ (("0"+dt.getDate()).slice(-2)) +"/"+ (dt.getFullYear()) +" "+ (("0"+dt.getHours()+1).slice(-2)) +":"+ (("0"+dt.getMinutes()+1).slice(-2));
 </script> -->
-    <script type='module' src="./tvefect.js"></script>
-    <script type='module' src="./sketch.js"></script>
+    <!-- <script type='module' src="./tvefect.js"></script>
+    <script type='module' src="./sketch.js"></script> -->
+    <script src="./tvefect.js"></script>
+    <script src="./sketch.js"></script>
     
   </body>
 </html>

--- a/sketch.js
+++ b/sketch.js
@@ -1,6 +1,6 @@
 
 // const {tv} = require('./tvefect');
-import tv from './tvefect.js';
+// import tv from './tvefect.js';
 
 function setup() {
   a = createCanvas(windowWidth, windowHeight, WEBGL);
@@ -57,7 +57,7 @@ function draw() {
 }
 
 function mouseClicked(){
-  tv();
+  window.tv();
   // console.log(mouseX, mouseY);
   // console.log(windowWidth, windowHeight);
   

--- a/tvefect.js
+++ b/tvefect.js
@@ -1,6 +1,7 @@
 // export tv;
 
-export default function tv () {
+// export default function tv () {
+function tv () {
 	"use strict";
 
 	var canvas = document.querySelector("#tv"),
@@ -89,3 +90,5 @@ export default function tv () {
 };
 
 // module.exports = {tv};
+
+window.tv = tv;


### PR DESCRIPTION
Usar la variable global window para exportar e importar funciones, constantes, etc.
Además, se quita el type="module" de los scripts que hacía que no se ejecutaran las funciones propias de p5js como setup() y draw()